### PR TITLE
Fix Cloud Run deployment errors

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,44 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies
+node_modules/
+
+# TypeScript source files (we only need the built files)
+*.ts
+*.tsx
+
+# Development files
+.storybook/
+stories/
+tests/
+coverage/
+
+# Configuration files
+.prettierrc
+.prettierignore
+vitest.config.ts
+tsconfig.json
+*.stories.tsx
+
+# Documentation
+*.md
+
+# Build artifacts
+dist/
+
+# Temporary files
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install all dependencies (including devDependencies for build)
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install only production dependencies
+RUN npm ci --only=production
+
+# Copy built application from builder stage
+COPY --from=builder /app/dist ./dist
+
+# Copy any other necessary files
+COPY tsconfig.json ./
+
+# Expose port (Cloud Run uses PORT environment variable)
+EXPOSE 8080
+
+# Start the application
+CMD ["npm", "start"]


### PR DESCRIPTION
- Add Dockerfile with multi-stage build to compile TypeScript
- Add .gcloudignore to exclude unnecessary files from deployment
- Fixes "tsc: not found" and missing dist/app module errors

🤖 Generated with [Claude Code](https://claude.ai/code)