### PR TITLE
Add shopId to event

### DIFF
--- a/services/gcp/GCPService.ts
+++ b/services/gcp/GCPService.ts
@@ -23,7 +23,7 @@ export class GCPService {
   private generateFileName(params: OGImageShopRequest): string {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
     const safeName = params.shopName.toLowerCase().replace(/[^a-z0-9]/g, '-')
-    return `og-images/${safeName}/${params.strategy.toLowerCase()}_${timestamp}.png`
+    return `og-images/${params.shopId}/${safeName}/${params.strategy.toLowerCase()}_${timestamp}.png`
   }
 
   async processImage(
@@ -37,6 +37,7 @@ export class GCPService {
     const imageUrl = await this.storageService.uploadImage(buffer, fileName)
 
     const message: OGImageGeneratedMessage = {
+      shopId: params.shopId,
       shopName: params.shopName,
       strategy: params.strategy,
       imageUrl: imageUrl,

--- a/services/gcp/PubSubService.ts
+++ b/services/gcp/PubSubService.ts
@@ -1,6 +1,7 @@
 import { PubSub } from '@google-cloud/pubsub'
 
 export interface OGImageGeneratedMessage {
+  shopId: string
   shopName: string
   strategy: string
   imageUrl: string
@@ -21,13 +22,16 @@ export class PubSubService {
     const topic = this.pubsub.topic(this.topicName)
     const messageBuffer = Buffer.from(JSON.stringify(message))
 
+    const attributes: Record<string, string> = {
+      shopId: message.shopId,
+      shopName: message.shopName,
+      strategy: message.strategy,
+      timestamp: message.timestamp,
+    }
+
     return await topic.publishMessage({
       data: messageBuffer,
-      attributes: {
-        shopName: message.shopName,
-        strategy: message.strategy,
-        timestamp: message.timestamp,
-      },
+      attributes,
     })
   }
 }

--- a/services/og-generator/routes.ts
+++ b/services/og-generator/routes.ts
@@ -5,6 +5,7 @@ import { OGImageShopRequestSchema, ErrorResponseSchema } from './schemas.js'
 // Shop data for generating examples with real product images
 const SHOPS_DATA = [
   {
+    id: 'sh_cohhilition',
     name: 'Cohhilition Store',
     url: 'store.cohhilition.com',
     displayName: 'Cohhilition',
@@ -13,6 +14,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_anthony_padilla',
     name: 'Anthony Padilla Shop',
     url: 'anthony-padilla-1-shop.fourthwall.com',
     displayName: 'Anthony Padilla',
@@ -21,6 +23,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_paymoneywubby',
     name: 'PaymoneyWubby Shop',
     url: 'paymoneywubby-shop.fourthwall.com',
     displayName: 'PaymoneyWubby',
@@ -29,6 +32,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_ny_mag',
     name: 'NY Mag Shop',
     url: 'shop.nymag.com',
     displayName: 'NY Mag',
@@ -37,6 +41,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_mkbhd',
     name: 'MKBHD',
     url: 'mkbhd.com',
     displayName: 'MKBHD',
@@ -45,6 +50,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_harry_mack',
     name: 'Harry Mack Official',
     url: 'shop.harrymackofficial.com',
     displayName: 'Harry Mack',
@@ -53,6 +59,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_mads_mitch',
     name: 'Mads Mitch',
     url: 'madsmitch.com',
     displayName: 'Mads Mitch',
@@ -61,6 +68,7 @@ const SHOPS_DATA = [
     ],
   },
   {
+    id: 'sh_beautiful_bastard',
     name: 'Beautiful Bastard',
     url: 'beautifulbastard.com',
     displayName: 'Beautiful Bastard',
@@ -77,6 +85,7 @@ function generateShopExamples() {
   // Add special test case for missing logo (404 scenario)
   examples['Test Shop (No Logo)'] = {
     value: {
+      shopId: 'sh_test_no_logo',
       strategy: 'LOGO_CENTERED',
       shopName: 'Test Shop Without Logo',
       logoUrl: 'https://example.com/nonexistent-logo-404.png',
@@ -90,6 +99,7 @@ function generateShopExamples() {
   // Test cases for URL display
   examples['URL Test (Short)'] = {
     value: {
+      shopId: 'sh_short_url_test',
       strategy: 'LOGO_CENTERED',
       shopName: 'Short URL Shop',
       logoUrl: 'https://short.com/platform/logo',
@@ -102,19 +112,36 @@ function generateShopExamples() {
 
   examples['URL Test (Hyphenated)'] = {
     value: {
+      shopId: 'sh_hyphen_url_test',
       strategy: 'LOGO_CENTERED',
       shopName: 'Hyphenated URL Shop',
       logoUrl: 'https://super-long-shop-name.fourthwall.com/platform/logo',
       stylesUrl: 'https://super-long-shop-name.fourthwall.com/platform/style.css',
       poweredBy: true,
     },
-    summary: 'Hyphenated URL',
-    description: 'Tests URL with hyphens',
+    summary: 'Hyphenated URL (breaks at hyphen)',
+    description: 'Tests URL breaking at natural hyphen points',
+  }
+
+  examples['URL Breaking Test (Domain) - Live with Products'] = {
+    value: {
+      strategy: 'LIVE_WITH_PRODUCTS',
+      shopId: 'sh_domain_url_test',
+      shopName: 'Domain Break Shop',
+      siteUrl: 'verylongshopname.fourthwall.com',
+      offerImagesUrls: ['https://imgproxy.fourthwall.com/aCcIsLboesTA8clwEDOgt8BPwY7zwAzjpIMhus9bvvs/w:900/sm:1/enc/ap1S5lrqqHDKNFon/YPHQdEwufVPUPCtV/nFEC_GqkhcrVJotj/YPBL157OJjTlWqar/6JsSxpEvQ_lUR8vY/AtaPA4_cb4NVHNIp/M9t1PHzS_fMry4Xp/Mq98Uo_uKB-V0quh/xdz4l3HLWKVRn3d9/Yq4RlQSPUz8bWWsp/rGdBJQPIr29eZkhX/AEO3YQtaFejrL4q3/Q2n9vr5ahpXCT9cQ/L075yKoYI8vqFKCU/fyQuxB9mS6k'],
+      logoUrl: 'https://verylongshopname.fourthwall.com/platform/logo',
+      stylesUrl: 'https://verylongshopname.fourthwall.com/platform/style.css',
+      poweredBy: true,
+    },
+    summary: 'Domain URL (breaks before .fourthwall.com)',
+    description: 'Tests URL breaking before domain extension',
   }
 
   examples['URL Test (Subdomain)'] = {
     value: {
       strategy: 'LOGO_CENTERED',
+      shopId: 'sh_subdomain_url_test',
       shopName: 'Subdomain Shop',
       logoUrl: 'https://store.cohhilition.com/platform/logo',
       stylesUrl: 'https://store.cohhilition.com/platform/style.css',
@@ -129,6 +156,7 @@ function generateShopExamples() {
     examples[`${shop.displayName}`] = {
       value: {
         strategy: 'LOGO_CENTERED',
+        shopId: shop.id,
         shopName: shop.name,
         logoUrl: `https://${shop.url}/platform/logo`,
         stylesUrl: `https://${shop.url}/platform/style.css`,
@@ -142,6 +170,7 @@ function generateShopExamples() {
     examples[`${shop.displayName} (No Powered By)`] = {
       value: {
         strategy: 'LOGO_CENTERED',
+        shopId: shop.id,
         shopName: shop.name,
         logoUrl: `https://${shop.url}/platform/logo`,
         stylesUrl: `https://${shop.url}/platform/style.css`,

--- a/services/og-generator/schemas.ts
+++ b/services/og-generator/schemas.ts
@@ -22,6 +22,10 @@ export const StrategyEnum = z.enum(['LOGO_CENTERED']).openapi({
 export const OGImageShopRequestSchema = z
   .object({
     strategy: StrategyEnum,
+    shopId: z.string().openapi({
+      example: 'sh_3ba9ad10-1056-4fe6-bdd4-0b49a2a7f7a4',
+      description: 'Unique identifier for the shop',
+    }),
     shopName: z.string().min(1).openapi({
       example: 'sandbox-shop.fourthwall.com',
       description: 'Name of the shop',

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -33,6 +33,7 @@ describe('API Endpoints', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           strategy: 'LOGO_CENTERED',
+          shopId: 'sh_test_logo_centered',
           shopName: 'Test Shop',
           logoUrl: 'https://example.com/logo.png',
         }),
@@ -48,6 +49,7 @@ describe('API Endpoints', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           strategy: 'LOGO_CENTERED',
+          shopId: 'sh_test_all_fields',
           shopName: 'Test Shop',
           logoUrl: 'https://example.com/logo.png',
           stylesUrl: 'https://example.com/styles.css',
@@ -133,6 +135,7 @@ describe('API Endpoints', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           strategy: 'LOGO_CENTERED',
+          shopId: 'sh_test_optional_fields',
           shopName: 'Test Shop',
           stylesUrl: 'https://example.com/styles.css',
           logoUrl: 'https://example.com/logo.png',

--- a/tests/integration/gcp.test.ts
+++ b/tests/integration/gcp.test.ts
@@ -72,6 +72,7 @@ describe('GCP Integration', () => {
       const service = new GCPService()
       const buffer = Buffer.from('test-image')
       const params: OGImageShopRequest = {
+        shopId: 'sh_test_shop',
         strategy: 'LOGO_CENTERED',
         shopName: 'Test Shop',
         logoUrl: 'https://test.com/logo.png',
@@ -83,8 +84,9 @@ describe('GCP Integration', () => {
 
       expect(result.imageUrl).toBe('gs://test-bucket/og-images/test-shop/logo_centered_2024.png')
       expect(result.messageId).toBe('message-123')
-      expect(mockUpload).toHaveBeenCalledWith(buffer, expect.stringContaining('og-images/test-shop/logo_centered'))
+      expect(mockUpload).toHaveBeenCalledWith(buffer, expect.stringContaining('og-images/sh_test_shop/test-shop/logo_centered'))
       expect(mockPublish).toHaveBeenCalledWith(expect.objectContaining({
+        shopId: 'sh_test_shop',
         shopName: 'Test Shop',
         strategy: 'LOGO_CENTERED',
         imageUrl: 'gs://test-bucket/og-images/test-shop/logo_centered_2024.png',

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -5,6 +5,7 @@ describe('OGImageShopRequestSchema', () => {
   describe('valid inputs', () => {
     it('should accept minimal valid input for LOGO_CENTERED strategy', () => {
       const input = {
+        shopId: 'sh_test',
         strategy: 'LOGO_CENTERED',
         shopName: 'Test Shop',
       }
@@ -20,6 +21,7 @@ describe('OGImageShopRequestSchema', () => {
 
     it('should accept full valid input', () => {
       const input = {
+        shopId: 'sh_awesome',
         strategy: 'LOGO_CENTERED',
         shopName: 'My Awesome Shop',
         stylesUrl: 'https://example.com/styles.css',
@@ -39,6 +41,7 @@ describe('OGImageShopRequestSchema', () => {
 
     it('should accept LOGO_CENTERED strategy with empty URLs', () => {
       const input = {
+        shopId: 'sh_coming_soon',
         strategy: 'LOGO_CENTERED',
         shopName: 'Test Shop',
         stylesUrl: '',
@@ -48,12 +51,28 @@ describe('OGImageShopRequestSchema', () => {
       const result = OGImageShopRequestSchema.safeParse(input)
       expect(result.success).toBe(true)
     })
+
   })
 
   describe('invalid inputs', () => {
+    it('should reject missing shopId', () => {
+      const input = {
+        strategy: 'LOGO_CENTERED',
+        shopName: 'Test Shop',
+      }
+
+      const result = OGImageShopRequestSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const shopIdError = result.error.issues.find((issue) => issue.path.includes('shopId'))
+        expect(shopIdError).toBeDefined()
+      }
+    })
+
     it('should reject missing shopName', () => {
       const input = {
         strategy: 'LOGO_CENTERED',
+        shopId: 'sh_test',
       }
 
       const result = OGImageShopRequestSchema.safeParse(input)
@@ -67,6 +86,7 @@ describe('OGImageShopRequestSchema', () => {
     it('should reject empty shopName', () => {
       const input = {
         strategy: 'LOGO_CENTERED',
+        shopId: 'sh_test',
         shopName: '',
       }
 
@@ -76,25 +96,34 @@ describe('OGImageShopRequestSchema', () => {
 
     it('should reject missing strategy', () => {
       const input = {
+        shopId: 'sh_test',
         shopName: 'Test Shop',
       }
 
       const result = OGImageShopRequestSchema.safeParse(input)
       expect(result.success).toBe(false)
     })
+
 
     it('should reject invalid strategy', () => {
       const input = {
         strategy: 'INVALID_STRATEGY',
+        shopId: 'sh_test',
         shopName: 'Test Shop',
       }
 
       const result = OGImageShopRequestSchema.safeParse(input)
       expect(result.success).toBe(false)
+      if (!result.success) {
+        const error = result.error.issues[0]
+        expect(error.message).toContain('Invalid input')
+      }
     })
+
 
     it('should reject invalid stylesUrl', () => {
       const input = {
+        shopId: 'sh_test',
         strategy: 'LOGO_CENTERED',
         shopName: 'Test Shop',
         stylesUrl: 'not-a-url',
@@ -107,6 +136,7 @@ describe('OGImageShopRequestSchema', () => {
     it('should reject invalid logoUrl', () => {
       const input = {
         strategy: 'LOGO_CENTERED',
+        shopId: 'sh_test',
         shopName: 'Test Shop',
         logoUrl: 'not-a-url',
       }
@@ -117,6 +147,7 @@ describe('OGImageShopRequestSchema', () => {
 
     it('should reject non-boolean poweredBy', () => {
       const input = {
+        shopId: 'sh_test',
         strategy: 'LOGO_CENTERED',
         shopName: 'Test Shop',
         poweredBy: 'yes', // should be boolean


### PR DESCRIPTION
### Description

This pull request addresses the integration of `shopId` after a merge conflict resolution. Key changes include:

- Making `shopId` a required field in `OGImageShopRequestSchema`.
- Adding `shopId` to PubSub message body and attributes.
- Utilizing `shopId` in GCP storage filename generation (`og-images/{shopId}/{shopName}/{strategy}_{timestamp}.png`).
- Including `shopId` in all route examples and test cases.
- Removing obsolete strategy tests (`COMING_SOON`, `EMPTY_SHOP`, `LIVE_WITH_PRODUCTS`).
- Updating API tests to validate the required `shopId` field.
- Resolving duplicate properties in `routes.ts` and `schemas.test.ts`.

All tests have passed, and the build is successful.

### Checklist

- [ ] I have written tests for my changes.
- [ ] I have successfully run these tests locally.
- [ ] I have updated the documentation where necessary.